### PR TITLE
Migrate from trivial-utf-8 to babel

### DIFF
--- a/fast-websocket.asd
+++ b/fast-websocket.asd
@@ -17,7 +17,7 @@
   :author "Eitaro Fukamachi"
   :license "BSD 2-Clause"
   :depends-on (:fast-io
-               :trivial-utf-8
+               :babel
                :alexandria)
   :components ((:module "src"
                 :components

--- a/src/compose.lisp
+++ b/src/compose.lisp
@@ -11,8 +11,8 @@
                 #:with-fast-output
                 #:fast-write-sequence
                 #:fast-write-byte)
-  (:import-from :trivial-utf-8
-                #:string-to-utf-8-bytes)
+  (:import-from :babel
+                #:string-to-octets)
   (:export #:compose-frame))
 (in-package :fast-websocket.compose)
 
@@ -38,8 +38,8 @@
         (setq code (error-code :normal-closure))))
 
   (when (stringp data)
-    ;; XXX: trivial-utf-8 doesn't seem to take 'start' and 'end'. Using subseq instead.
-    (setq data (string-to-utf-8-bytes (subseq data start end)))
+    (setq data (babel:string-to-octets
+                data :encoding :utf-8 :start start :end end))
     (setq start 0
           end (length data)))
 


### PR DESCRIPTION
The fast-websocket library depends on both trivial-utf-8 and babel: trivial-utf-8 directly, but babel indirectly through fast-io >> static-vectors >> cffi >> babel:

![fast-websocket dependency graph](https://user-images.githubusercontent.com/41240025/107464410-11ad7e00-6b15-11eb-994f-d98b81fba881.png)

This change removes trivial-utf-8 as a dependency by moving to a library it is already dependent on.


Only thing I'm not personally happy with the change is now having to explicitly specify `utf-8` for each call, but since it's called infrequently enough I don't think that should be a major problem. babel's and trivial's APIs are nearly 1-to-1 for the relevant parts, the tests all pass on my machine, and my dependent project still works with the change. I hope this will be a smooth pull request!