### PR TITLE
Fix: accumulate until full data is received for frame

### DIFF
--- a/src/parser.lisp
+++ b/src/parser.lisp
@@ -154,11 +154,8 @@
              (funcall (the function payload-callback)
                       data
                       :start i
-                      :end next-end))
-
-           (when (and (ws-fin ws)
-                      (= (ws-opcode ws) #.(opcode :continuation)))
-             (setf (ws-mode ws) nil))
+                      :end next-end
+                      :partial-frame read-a-part))
 
            (if read-a-part
                (progn
@@ -168,6 +165,10 @@
                  (setf (ws-stage ws) 0)
 
                  (setq i next-end)
+
+                 (when (and (ws-fin ws)
+                            (= (ws-opcode ws) #.(opcode :continuation)))
+                   (setf (ws-mode ws) nil))
 
                  (unless (= i end)
                    (go parsing-first-byte)))))

--- a/src/payload.lisp
+++ b/src/payload.lisp
@@ -32,6 +32,6 @@
   (with-masking (byte data :start start :end end :mask-keys mask-keys)
     (fast-write-byte byte output-buffer)))
 
-(defun mask-message (data mask-keys)
-  (with-masking (byte data :start 0 :end (length data) :i i :mask-keys mask-keys)
+(defun mask-message (data mask-keys &optional (start 0) (end (length data)))
+  (with-masking (byte data :start start :end end :i i :mask-keys mask-keys)
     (setf (aref data i) byte)))


### PR DESCRIPTION
This is because full data of a frame doesn't necessarily come in a single tcp
packet and a single websocket frame supports much larger data length than tcp

(This pr is stacked on top of #12 )